### PR TITLE
[version] update version to 1.0.4 (latest)

### DIFF
--- a/libwatchgod/version.go
+++ b/libwatchgod/version.go
@@ -1,3 +1,3 @@
 package watchgod
 
-var VERSION = "1.0.2"
+var VERSION = "1.0.4"


### PR DESCRIPTION
The current version return `1.0.2` even with the latest version 1.0.4

$> watchgod version
Client version 1.0.2
Deamon version 1.0.2